### PR TITLE
refactor: remove use of must in test

### DIFF
--- a/src/asl-mock.ts
+++ b/src/asl-mock.ts
@@ -20,6 +20,7 @@ program
   .requiredOption("-i --input <input>", "path to mock config ts file")
   .requiredOption("-a --asl <asl>", "relative path to asl src during test")
   .option("-o --out <out>", "path for emitted test file")
+  .option("--no-esm", "disables esm style imports")
   .parse(process.argv);
 
 function outputFileFromInput(input: string): string {
@@ -36,6 +37,7 @@ function generateTestFile(): void {
       input: string;
       asl: string;
       out?: string;
+      esm: boolean;
     } = program.opts();
 
     const { found, mockConfigTypeArgs, stateMachines, decl } =
@@ -59,6 +61,7 @@ function generateTestFile(): void {
       mockConfigTypeArgs,
       mockConfig: decl,
       aslTestRunnerPath: "asl-mock",
+      esm: opts.esm,
     });
     const outputFile = opts.out ?? outputFileFromInput(opts.input);
     fs.writeFileSync(outputFile, output, "utf-8");

--- a/src/example-crm/.asl-puml/CustomValidationFailedCatchTest.puml
+++ b/src/example-crm/.asl-puml/CustomValidationFailedCatchTest.puml
@@ -14,9 +14,9 @@ skinparam state {
     FontColor<<CustomStyle0>> automatic
     BackgroundColor<<CustomStyle0>> #86ea9f
     FontColor<<CustomStyle1>> automatic
-    BackgroundColor<<CustomStyle1>> #red
+    BackgroundColor<<CustomStyle1>> #2b665e
     FontColor<<CustomStyle2>> automatic
-    BackgroundColor<<CustomStyle2>> #2b665e
+    BackgroundColor<<CustomStyle2>> #red
     FontColor<<CustomStyle3>> automatic
     BackgroundColor<<CustomStyle3>> #2b665e
     FontColor<<CustomStyle4>> gray
@@ -24,10 +24,10 @@ skinparam state {
 }
 state "Validation" as state1<<CustomStyle0>> {
 state "Branch 1" as state1_1 {
-state "Check Identity" as state9<<CustomStyle1>>
+state "Check Identity" as state9<<CustomStyle2>>
 }
 state "Branch 2" as state1_2 {
-state "Check Address" as state10<<CustomStyle2>>
+state "Check Address" as state10<<CustomStyle1>>
 }
 }
 state "DetectSentiment" as state2<<CustomStyle4>>

--- a/src/example-crm/.asl-puml/NegativeSentimentTest.puml
+++ b/src/example-crm/.asl-puml/NegativeSentimentTest.puml
@@ -28,10 +28,10 @@ skinparam state {
 }
 state "Validation" as state1<<CustomStyle0>> {
 state "Branch 1" as state1_1 {
-state "Check Identity" as state9<<CustomStyle1>>
+state "Check Identity" as state9<<CustomStyle2>>
 }
 state "Branch 2" as state1_2 {
-state "Check Address" as state10<<CustomStyle2>>
+state "Check Address" as state10<<CustomStyle1>>
 }
 }
 state "DetectSentiment" as state2<<CustomStyle3>>

--- a/src/example-crm/crm-comment.asl.test.ts
+++ b/src/example-crm/crm-comment.asl.test.ts
@@ -8,10 +8,9 @@ import type {
   TestCases,
 } from "./crm-comment.mock";
 import { CrmCommentMock, StartMessages } from "./crm-comment.mock";
-import { must } from "asl-puml";
 
-jest.setTimeout(180 * 1000);
 describe("tests for crm-comment.asl.json", () => {
+  const TIMEOUT = 30 * 1000;
   const outdir = path.join(__dirname, ".asl-puml");
 
   let _aslRunner: AslTestRunner<
@@ -23,7 +22,6 @@ describe("tests for crm-comment.asl.json", () => {
   > | null = null;
 
   beforeAll(async () => {
-    const dirname = new URL(".", import.meta.url).pathname;
     _aslRunner = await AslTestRunner.createRunner<
       StateMachineNames,
       TestCases,
@@ -32,7 +30,7 @@ describe("tests for crm-comment.asl.json", () => {
       CustomErrors
     >(CrmCommentMock, {
       "crm-comment": path.join(
-        dirname,
+        __dirname,
         "../../src/example-crm/crm-comment.asl.json"
       ),
     });
@@ -53,69 +51,84 @@ describe("tests for crm-comment.asl.json", () => {
       logHistoryEventsOnFailure: true,
     };
 
-    it("scenario HappyPathTest", async () => {
-      expect.hasAssertions();
-      must(_aslRunner);
-      await _aslRunner.execute(
-        {
-          name: "crm-comment",
-          startMessage: StartMessages["HappyPathTest"],
-          scenario: "HappyPathTest",
-        },
-        afterCompletion
-      );
-    });
+    it(
+      "scenario HappyPathTest",
+      async () => {
+        expect.hasAssertions();
+        await _aslRunner?.execute(
+          {
+            name: "crm-comment",
+            startMessage: StartMessages["HappyPathTest"],
+            scenario: "HappyPathTest",
+          },
+          afterCompletion
+        );
+      },
+      TIMEOUT
+    );
 
-    it("scenario NegativeSentimentTest", async () => {
-      expect.hasAssertions();
-      must(_aslRunner);
-      await _aslRunner.execute(
-        {
-          name: "crm-comment",
-          startMessage: StartMessages["NegativeSentimentTest"],
-          scenario: "NegativeSentimentTest",
-        },
-        afterCompletion
-      );
-    });
+    it(
+      "scenario NegativeSentimentTest",
+      async () => {
+        expect.hasAssertions();
+        await _aslRunner?.execute(
+          {
+            name: "crm-comment",
+            startMessage: StartMessages["NegativeSentimentTest"],
+            scenario: "NegativeSentimentTest",
+          },
+          afterCompletion
+        );
+      },
+      TIMEOUT
+    );
 
-    it("scenario CustomValidationFailedCatchTest", async () => {
-      expect.hasAssertions();
-      must(_aslRunner);
-      await _aslRunner.execute(
-        {
-          name: "crm-comment",
-          startMessage: StartMessages["CustomValidationFailedCatchTest"],
-          scenario: "CustomValidationFailedCatchTest",
-        },
-        afterCompletion
-      );
-    });
+    it(
+      "scenario CustomValidationFailedCatchTest",
+      async () => {
+        expect.hasAssertions();
+        await _aslRunner?.execute(
+          {
+            name: "crm-comment",
+            startMessage: StartMessages["CustomValidationFailedCatchTest"],
+            scenario: "CustomValidationFailedCatchTest",
+          },
+          afterCompletion
+        );
+      },
+      TIMEOUT
+    );
 
-    it("scenario ValidationExceptionCatchTest", async () => {
-      expect.hasAssertions();
-      must(_aslRunner);
-      await _aslRunner.execute(
-        {
-          name: "crm-comment",
-          startMessage: StartMessages["ValidationExceptionCatchTest"],
-          scenario: "ValidationExceptionCatchTest",
-        },
-        afterCompletion
-      );
-    });
+    it(
+      "scenario ValidationExceptionCatchTest",
+      async () => {
+        expect.hasAssertions();
+        await _aslRunner?.execute(
+          {
+            name: "crm-comment",
+            startMessage: StartMessages["ValidationExceptionCatchTest"],
+            scenario: "ValidationExceptionCatchTest",
+          },
+          afterCompletion
+        );
+      },
+      TIMEOUT
+    );
 
-    it("scenario RetryOnServiceExceptionTest", async () => {
-      expect.hasAssertions();
-      must(_aslRunner);
-      await _aslRunner.execute(
-        {
-          name: "crm-comment",
-          startMessage: StartMessages["RetryOnServiceExceptionTest"],
-          scenario: "RetryOnServiceExceptionTest",
-        },
-        afterCompletion
-      );
-    });
+    it(
+      "scenario RetryOnServiceExceptionTest",
+      async () => {
+        expect.hasAssertions();
+        await _aslRunner?.execute(
+          {
+            name: "crm-comment",
+            startMessage: StartMessages["RetryOnServiceExceptionTest"],
+            scenario: "RetryOnServiceExceptionTest",
+          },
+          afterCompletion
+        );
+      },
+      TIMEOUT
+    );
   });
 });

--- a/src/lib/generate-test.test.ts
+++ b/src/lib/generate-test.test.ts
@@ -23,6 +23,7 @@ describe("tests the generation of units tests from mock config", () => {
       mockConfigTypeArgs,
       mockConfig: decl,
       aslTestRunnerPath: "../lib/runner",
+      esm: false,
     });
     expect(output).toBeDefined();
     fs.writeFileSync(outFile, output, "utf-8");


### PR DESCRIPTION
feat: add esm option for imports and dirname
refactor: moved timeout param to arg to avoid using jest global

closes #10 
closes #11 
closes #12 
